### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ class PhpVersion extends AbstractPolicyCheckBase
         return 'PHP';
     }
 
-    public function getRiskLevel()
+    public function getSeverity()
     {
-        return parent::POLICY_RISK_HIGH;
+        return parent::POLICY_SEVERITY_HIGH;
     }
 
     public function getResultPassMessage()


### PR DESCRIPTION
`getRiskLevel` was renamed `getSeverity` on https://github.com/EdisonLabs/policy-verification/commit/15499fd00a4fb0884d19e5744fbf1f380b9e4fe6