### PR TITLE
Allow passing policies to provide actions

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -391,7 +391,7 @@ class Report
                 'result' => $policyCheck->getResult(),
                 'message' => $policyCheck->getResultMessage(),
                 'warnings' => $policyCheck->getWarnings(),
-                'actions' => $policyCheck->isFail() ? $policyCheck->getActions() : [],
+                'actions' => $policyCheck->getActions(),
                 'severity' => $policyCheck->getSeverity(),
             ];
         }

--- a/tests/src/Unit/PolicyVerificationCommandTest.php
+++ b/tests/src/Unit/PolicyVerificationCommandTest.php
@@ -107,7 +107,7 @@ class PolicyVerificationCommandTest extends TestCase
         unset($output['timestamp']);
         $output = json_encode($output);
 
-        $this->assertContains('{"data":{"pass":1},"result":true,"summary":{"total":1,"total_pass":1,"total_fail":0,"percentage_pass":100},"policies":{"test":{"example_policy_check":{"name":"Example policy check","description":"This is an example of a policy check","category":"Test","requirement_errors":[],"result":true,"message":"The policy passes","warnings":["Just an example of warning message"],"actions":[],"severity":"high"}}},"messages":{"pass":["The policy passes"],"fail":[],"action":[],"warning":["Just an example of warning message"],"requirement_error":[]}}', $output);
+        $this->assertContains('{"data":{"pass":1},"result":true,"summary":{"total":1,"total_pass":1,"total_fail":0,"percentage_pass":100},"policies":{"test":{"example_policy_check":{"name":"Example policy check","description":"This is an example of a policy check","category":"Test","requirement_errors":[],"result":true,"message":"The policy passes","warnings":["Just an example of warning message"],"actions":["Just an action example."],"severity":"high"}}},"messages":{"pass":["The policy passes"],"fail":[],"action":[],"warning":["Just an example of warning message"],"requirement_error":[]}}', $output);
 
         // Test exceptions.
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
Currently only if the policy fails actions are added to the summary.

There is a usecase for a passing policy to provide actions to be taken, for example in the case of a policy not yet enforced, but that will be in the near future.